### PR TITLE
Fix bug where files were duplicated after passing through filenames.

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -20,7 +20,6 @@ module.exports = (name, options = {}) ->
 
     if file.isBuffer()
       module.exports.register(file, name, options)
-      @push file
 
     done(null, file)
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@
       }
       if (file.isBuffer()) {
         module.exports.register(file, name, options);
-        this.push(file);
       }
       return done(null, file);
     };


### PR DESCRIPTION
Both the `@push file` and `done(null, file)` added the file into the stream output. This resulted in two copies of the file in the stream after gulp-filenames was invoked, causing double processing. It's easy to verify with the following code:

``` js
var gulp = require('gulp');
var debug = require('gulp-debug');
var filenames = require('gulp-filenames');

gulp.task('default', function () {
    return gulp.src('/test/**.*')
        .pipe(debug({title: 'before'}))
        .pipe(filenames('testing'))
        .pipe(debug({title: 'after'}))
});
```

From the through2 docs [here](https://github.com/rvagg/through2)

``` js
fs.createReadStream('/tmp/important.dat')
  .pipe(through2({ objectMode: true, allowHalfOpen: false },
    function (chunk, enc, cb) {
      cb(null, 'wut?') // note we can use the second argument on the callback
                       // to provide data as an alternative to this.push('wut?')
    }
  )
  .pipe(fs.createWriteStream('/tmp/wut.txt'))
```

The tests pass. 

Do you have a global coffee config file that specifies "-c" option? I found that `npm run build` didn't actually create a new .js file. Nor did it when I ran `coffee index.coffee` directly. It required that I ran `coffee -c index.coffee`. I'm not a coffeescript user, except for this project, so I may be missing something very basic.
